### PR TITLE
Add an option to leave EOS off the source side

### DIFF
--- a/configurations.py
+++ b/configurations.py
@@ -35,6 +35,7 @@ def base():
     config['att_dropout'] = 0.3
     config['ff_dropout'] = 0.3
     config['word_dropout'] = 0.1
+    config['source_eos'] = True
 
     # Decoding
     config['beam_size'] = 4

--- a/data_manager.py
+++ b/data_manager.py
@@ -74,7 +74,9 @@ class DataManager(object):
         lens = []
         raw_data = self.io.load_bpe_data(pair, mode, src=True, input_file=input_file)
         for tokenized_line in raw_data:
-            ids = [self.vocab.get(tok, ac.UNK_ID) for tok in tokenized_line] + [ac.EOS_ID]
+            ids = [self.vocab.get(tok, ac.UNK_ID) for tok in tokenized_line]
+            if self.args.source_eos:
+                ids = ids + [ac.EOS_ID]
             data.append(ids)
             lens.append(len(ids))
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -30,6 +30,8 @@ def get_parser():
                         help='whether to oversample training data so all languages are more fairly represented')
     parser.add_argument('--alpha', type=float, default=0.5,
                         help='oversampling prob when learning bpe, see https://arxiv.org/pdf/1901.07291.pdf')
+    parser.add_argument('--source-eos', choices=('True','False'), default='True',
+                        help='whether to append EOS to the end of the source sentence')
     return parser
 
 if __name__ == '__main__':
@@ -323,7 +325,9 @@ if __name__ == '__main__':
                     tgt_toks = tgt_line.strip().split()
 
                     if src_toks and tgt_toks:
-                        src_toks = [joint_vocab.get(tok, ac.UNK_ID) for tok in src_toks] + [ac.EOS_ID]
+                        src_toks = [joint_vocab.get(tok, ac.UNK_ID) for tok in src_toks]
+                        if args.source_eos == 'True':
+                            src_toks = src_toks + [ac.EOS_ID]
                         tgt_toks = [ac.BOS_ID] + [joint_vocab.get(tok, ac.UNK_ID) for tok in tgt_toks]
                         src_data.append(src_toks)
                         tgt_data.append(tgt_toks)


### PR DESCRIPTION
Just in case it's relevant to our experiments

(To do this correctly you need to set the option in processing.py *and* in the main code. Ideally, would refactor a bit to make this more elegant, but there's no time.)