### PR TITLE
Change pair format from en2vi to en_vi

### DIFF
--- a/configurations.py
+++ b/configurations.py
@@ -47,7 +47,7 @@ def base():
     return config
 
 
-def en2vi():
+def en_vi():
     config = base()
     config['epoch_size'] = 1500
     return config

--- a/controller.py
+++ b/controller.py
@@ -263,7 +263,7 @@ class Controller(object):
         avg_ppls = []
         with torch.no_grad():
             for pair in self.pairs:
-                src_lang, tgt_lang = pair.split('2')
+                src_lang, tgt_lang = pair.split('_')
                 src_lang_idx = self.data_manager.lang_vocab[src_lang]
                 tgt_lang_idx = self.data_manager.lang_vocab[tgt_lang]
                 loss = 0.
@@ -373,7 +373,7 @@ class Controller(object):
         return all_best_trans, all_beam_trans
 
     def translate(self, pair, mode, input_file=None, batch_size=4096):
-        src_lang, tgt_lang = pair.split('2')
+        src_lang, tgt_lang = pair.split('_')
 
         src_lang_idx = self.data_manager.lang_vocab[src_lang]
         tgt_lang_idx = self.data_manager.lang_vocab[tgt_lang]

--- a/data_manager.py
+++ b/data_manager.py
@@ -58,7 +58,7 @@ class DataManager(object):
             self.train_iters[pair] = self.data[pair][ac.TRAIN].get_iter(shuffle=True)
             src, tgt, targets = next(self.train_iters[pair])
 
-        src_lang, tgt_lang = pair.split('2')
+        src_lang, tgt_lang = pair.split('_')
         return {
             'src': src,
             'tgt': tgt,

--- a/io_and_bleu.py
+++ b/io_and_bleu.py
@@ -69,7 +69,7 @@ class IO(object):
             data_files[lang]['mask'] = mask_file
         
         for pair in self.pairs:
-            src_lang, tgt_lang = pair.split('2')
+            src_lang, tgt_lang = pair.split('_')
             data_files[pair] = {}
             for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
                 data_files[pair][mode] = {}

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def get_parser():
     parser.add_argument('--translate-test', choices=('True','False'), default='False',
                         help='Used if in train_and_translate or translate mode, says whether to translate the test.[lang].bpe files in the processed data directory')
     parser.add_argument('--files-langs', type=str, nargs='+',
-                        help='Used if in train_and_translate or translate node, specifies which files to translate, format {input_filepath,output_filename,src_lang2tgt_lang...}. e.g.: data/test.en.bpe,test.en2vi.bpe,en2vi data/test.vi.bpe,test.vi2en.bpe,vi2en')
+                        help='Used if in train_and_translate or translate node, specifies which files to translate, format {input_filepath,output_filename,src_tgt...}. e.g.: data/test.en.bpe,test.en_vi.bpe,en_vi data/test.vi.bpe,test.vi_en.bpe,vi_en')
 
     parser.add_argument('--raw-data-dir', type=str, required=True,
                         help='Path to original data directory')
@@ -33,7 +33,7 @@ def get_parser():
                         help='Path to translate directory (where to output the translations)')
 
     parser.add_argument('--pairs', type=str, required=True,
-                        help='Command separated list of pairs in format src2tgt, e.g. en2vi,hu2en,uz2en')
+                        help='Comma separated list of pairs in format src_tgt, e.g. en_vi,hu_en,uz_en')
     parser.add_argument('--bleu-script', type=str, default='./scripts/multi-bleu.perl',
                         help='Path to multi-bleu.perl script')
     parser.add_argument('--log-freq', type=int, default=100,

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -19,7 +19,7 @@ def get_parser():
     parser.add_argument('--fast', type=str, required=True,
                         help='path to fastBPE binary')
     parser.add_argument('--pairs', type=str, required=True,
-                        help='command-separated list of language pairs, e.g. en2vi,ar2en,gl2en')
+                        help='comma-separated list of language pairs, e.g. en_vi,ar_en,gl_en')
     parser.add_argument('--num-ops', type=str, required=True,
                         help='number of BPE operations (if joint BPE, provide one number; if separate BPE, provide a number for each language, like en:6000,vi:6000)')
     parser.add_argument('--max-vocab-size', type=int, default=0,
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     pairs = list(sorted(args.pairs.split(',')))
     langs = []
     for pair in pairs:
-        langs.extend(pair.split('2'))
+        langs.extend(pair.split('_'))
     langs = list(sorted(set(langs)))
     print('Languages: ', langs)
 
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     bpe_files = {}
     npy_files = {}
     for pair in pairs:
-        for lang in pair.split('2'):
+        for lang in pair.split('_'):
             for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
                 input_files[(pair, lang, mode)] = join(raw_dir, f'{pair}/{mode}.{lang}')
                 bpe_files[(pair, lang, mode)] = join(proc_dir, f'{pair}/{mode}.{lang}.bpe')
@@ -119,7 +119,7 @@ if __name__ == '__main__':
     print('Grouping data together by language')
     datas = {lang: [] for lang in langs}
     for pair in pairs:
-        for lang in pair.split('2'):
+        for lang in pair.split('_'):
             infile = input_files[(pair, lang, ac.TRAIN)]
             with open(infile, 'r') as fin:
                 datas[lang].extend(fin.readlines())
@@ -209,7 +209,7 @@ if __name__ == '__main__':
         # the BPE vocab for [lang] consists of all BPE tokens which only appeared in [lang].
         # this is necessary for encoding the dev/test data, since we only want to encode it
         # using tokens which appeared during training.
-        # (example: say that we're doing de2en, and during training, we see the token 'ation'
+        # (example: say that we're doing de_en, and during training, we see the token 'ation'
         #  in the en data but not the de data. when encoding the dev and test data, we want
         #  to make sure not to use 'ation' on the de side, since the tranformer will not have
         #  seen that token on the de side during training.)
@@ -229,7 +229,7 @@ if __name__ == '__main__':
         # applying BPE to train,dev,test
         print('Apply BPE to all data')
         for pair in pairs:
-            for lang in pair.split('2'):
+            for lang in pair.split('_'):
                 bpe_vocab_file = bpe_vocab_files[lang]
                 for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
                     infile = input_files[(pair, lang, mode)]
@@ -256,7 +256,7 @@ if __name__ == '__main__':
         # (no need to learn vocab when doing separate BPE)
         print('Apply BPE to all data')
         for pair in pairs:
-            for lang in pair.split('2'):
+            for lang in pair.split('_'):
                 for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
                     infile = input_files[(pair, lang, mode)]
                     encoded_file = bpe_files[(pair, lang, mode)]
@@ -271,7 +271,7 @@ if __name__ == '__main__':
     joint_vocab = Counter()
     sub_vocabs = {lang: Counter() for lang in langs}
     for pair in pairs:
-        for lang in pair.split('2'):
+        for lang in pair.split('_'):
             infile = bpe_files[(pair, lang, ac.TRAIN)]
             with open(infile, 'r') as fin:
                 for line in fin:
@@ -316,7 +316,7 @@ if __name__ == '__main__':
             # read in parallel to make sure we remove empty lines
             src_data = []
             tgt_data = []
-            src_lang, tgt_lang = pair.split('2')
+            src_lang, tgt_lang = pair.split('_')
             src_infile = bpe_files[(pair, src_lang, mode)]
             tgt_infile = bpe_files[(pair, tgt_lang, mode)]
             with open(src_infile, 'r') as f_src, open(tgt_infile, 'r') as f_tgt:


### PR DESCRIPTION
This way, I can use numbers in the language pair names (important when labeling the source sides with different %s included)